### PR TITLE
Use std::terminate in HandleCrashServer

### DIFF
--- a/src/Server/ChatCommandStore.cpp
+++ b/src/Server/ChatCommandStore.cpp
@@ -8,6 +8,8 @@
 #include <Server/ServerApplication.hpp>
 #include <Server/Components/HealthComponent.hpp>
 
+#include <exception>
+
 namespace ewn
 {
 	bool ChatCommandStore::ExecuteCommand(const std::string_view& name, Player* player)
@@ -35,7 +37,7 @@ namespace ewn
 		if (player->GetName() != "Lynix")
 			return false;
 
-		*static_cast<volatile int*>(nullptr) = 42;
+		std::terminate();
 
 		return true;
 	}


### PR DESCRIPTION
Using `std::terminate` for abnormal program termination is cleaner and has more semantic meaning than a null pointer dereference. In addition, dereferencing a null pointer is undefined behavior and doesn't guarantee a crash.